### PR TITLE
Refresh each domains with a 24 hour cooldown in it

### DIFF
--- a/prisma/migrations/20250315054533_add_last_refreshed_at/migration.sql
+++ b/prisma/migrations/20250315054533_add_last_refreshed_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Domain" ADD COLUMN     "lastRefreshedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model Domain {
   domainExpiryDate  DateTime?
   domainCreatedDate DateTime?
   domainUpdatedDate DateTime?
+  lastRefreshedAt   DateTime?
   registrar         String?
   emails           String?
   createdAt        DateTime @default(now())

--- a/src/hooks/use-domains.ts
+++ b/src/hooks/use-domains.ts
@@ -8,6 +8,11 @@ interface Domain {
   id: string;
   name: string;
   domainExpiryDate: string | null;
+  domainCreatedDate?: string | null;
+  domainUpdatedDate?: string | null;
+  lastRefreshedAt?: string | null;
+  registrar?: string | null;
+  emails?: string | null;
   createdAt: string;
   updatedAt: string | null;
 }
@@ -286,17 +291,20 @@ export function useRefreshDomainWhois() {
 
   return useMutation({
     mutationFn: async (domainId: string) => {
+      // Use a relative URL to avoid port issues
       const response = await fetch(`/api/domains/${domainId}/lookup`, {
-        method: "POST",
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        }
       });
 
       if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || "Failed to refresh domain information");
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to refresh domain information');
       }
 
-      const result = await response.json();
-      return result;
+      return await response.json();
     },
     onSuccess: (data) => {
       // Show success toast

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,122 @@
+/**
+ * API Client for making requests to the backend
+ * This ensures consistent API calls throughout the application
+ */
+
+const getBaseUrl = () => {
+  // In the browser, use the current window location
+  if (typeof window !== "undefined") {
+    const { protocol, hostname, port } = window.location;
+    return `${protocol}//${hostname}${port ? `:${port}` : ""}`;
+  }
+
+  // In server-side rendering, use environment variable or default
+  return process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3000";
+};
+
+interface RequestOptions extends RequestInit {
+  params?: Record<string, string>;
+}
+
+/**
+ * Makes a fetch request to the API
+ */
+export async function apiRequest<T>(
+  endpoint: string,
+  options: RequestOptions = {}
+): Promise<T> {
+  const { params, ...fetchOptions } = options;
+
+  // Build the URL with query parameters if provided
+  let url = `${getBaseUrl()}${endpoint}`;
+  if (params) {
+    const queryParams = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        queryParams.append(key, value);
+      }
+    });
+    const queryString = queryParams.toString();
+    if (queryString) {
+      url += `?${queryString}`;
+    }
+  }
+
+  // Set default headers
+  const headers = new Headers(fetchOptions.headers);
+  if (
+    !headers.has("Content-Type") &&
+    !(fetchOptions.body instanceof FormData)
+  ) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  // Make the request
+  const response = await fetch(url, {
+    ...fetchOptions,
+    headers,
+  });
+
+  // Handle response
+  if (!response.ok) {
+    let errorData;
+    try {
+      errorData = await response.json();
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (_) {
+      errorData = { error: response.statusText };
+    }
+    throw new Error(errorData.error || "API request failed");
+  }
+
+  // Return JSON response or empty object if no content
+  if (response.status === 204) {
+    return {} as T;
+  }
+
+  return response.json() as Promise<T>;
+}
+
+/**
+ * API client with methods for common HTTP verbs
+ */
+export const apiClient = {
+  get: <T>(endpoint: string, options?: RequestOptions) =>
+    apiRequest<T>(endpoint, { ...options, method: "GET" }),
+
+  post: <T>(
+    endpoint: string,
+    data?: Record<string, unknown>,
+    options?: RequestOptions
+  ) =>
+    apiRequest<T>(endpoint, {
+      ...options,
+      method: "POST",
+      body: data ? JSON.stringify(data) : undefined,
+    }),
+
+  put: <T>(
+    endpoint: string,
+    data?: Record<string, unknown>,
+    options?: RequestOptions
+  ) =>
+    apiRequest<T>(endpoint, {
+      ...options,
+      method: "PUT",
+      body: data ? JSON.stringify(data) : undefined,
+    }),
+
+  patch: <T>(
+    endpoint: string,
+    data?: Record<string, unknown>,
+    options?: RequestOptions
+  ) =>
+    apiRequest<T>(endpoint, {
+      ...options,
+      method: "PATCH",
+      body: data ? JSON.stringify(data) : undefined,
+    }),
+
+  delete: <T>(endpoint: string, options?: RequestOptions) =>
+    apiRequest<T>(endpoint, { ...options, method: "DELETE" }),
+};

--- a/src/models/domain.model.ts
+++ b/src/models/domain.model.ts
@@ -8,6 +8,7 @@ export interface DomainModel {
   domainExpiryDate: Date | null;
   domainCreatedDate: Date | null;
   domainUpdatedDate: Date | null;
+  lastRefreshedAt: Date | null;
   registrar: string | null;
   emails: string | null;
   response: JsonValue | null;
@@ -20,6 +21,8 @@ export interface DomainResponse {
   name: string;
   domainExpiryDate: Date | null;
   domainCreatedDate: Date | null;
+  domainUpdatedDate: Date | null;
+  lastRefreshedAt: Date | null;
   registrar: string | null;
   emails: string | null;
   response: JsonValue | null;
@@ -27,17 +30,33 @@ export interface DomainResponse {
   updatedAt: Date | null;
 }
 
-export const serializeDomain = (domain: PrismaDomain): DomainResponse => ({
-  id: domain.id.toString(),
-  name: domain.name,
-  domainExpiryDate: domain.domainExpiryDate,
-  domainCreatedDate: domain.domainCreatedDate,
-  registrar: domain.registrar,
-  emails: domain.emails,
-  response: domain.response,
-  createdAt: domain.createdAt,
-  updatedAt: domain.updatedAt,
-});
+export interface DomainLookupResponse {
+  success: boolean;
+  onCooldown?: boolean;
+  hoursRemaining?: number;
+  message?: string;
+  domain: DomainResponse;
+}
+
+export const serializeDomain = (domain: PrismaDomain): DomainResponse => {
+  // Extract lastRefreshedAt with proper type handling
+  const extendedDomain = domain as PrismaDomain & { lastRefreshedAt?: Date | null };
+  const lastRefreshedAt = extendedDomain.lastRefreshedAt || null;
+  
+  return {
+    id: domain.id.toString(),
+    name: domain.name,
+    domainExpiryDate: domain.domainExpiryDate,
+    domainCreatedDate: domain.domainCreatedDate,
+    domainUpdatedDate: domain.domainUpdatedDate,
+    lastRefreshedAt,
+    registrar: domain.registrar,
+    emails: domain.emails,
+    response: domain.response,
+    createdAt: domain.createdAt,
+    updatedAt: domain.updatedAt,
+  };
+};
 
 export const validateDomain = (domain: string): boolean => {
   return DomainValidationService.validateDomain(domain);

--- a/src/services/domain.service.ts
+++ b/src/services/domain.service.ts
@@ -42,19 +42,23 @@ export class DomainService {
     // Sanitize and validate domain
     const sanitizedDomain = sanitizeDomain(domainName);
     if (!sanitizedDomain || !validateDomain(sanitizedDomain)) {
-      // Return a default DomainResponse object with error indication
-      // We use an empty id to indicate an error state that the UI can check for
-      return {
-        id: "",
+      // Create a mock domain object that matches the Prisma schema
+      const mockDomain = {
+        id: BigInt(0), // Use BigInt(0) instead of empty string
         name: domainName,
         domainExpiryDate: null,
         domainCreatedDate: null,
+        domainUpdatedDate: null,
+        lastRefreshedAt: null,
         registrar: null,
         emails: null,
         response: null,
         createdAt: new Date(),
-        updatedAt: null,
+        updatedAt: new Date(), // Use new Date() instead of null
       };
+
+      // Return a serialized domain with error indication
+      return serializeDomain(mockDomain);
     }
 
     // Check if domain already exists
@@ -76,17 +80,7 @@ export class DomainService {
 
     // If user already has this domain, return it as a duplicate
     if (existingUserDomain && existingDomain) {
-      return {
-        id: existingDomain.id.toString(),
-        name: existingDomain.name,
-        domainExpiryDate: existingDomain.domainExpiryDate,
-        domainCreatedDate: existingDomain.domainCreatedDate,
-        registrar: existingDomain.registrar,
-        emails: existingDomain.emails,
-        response: existingDomain.response,
-        createdAt: existingDomain.createdAt,
-        updatedAt: existingDomain.updatedAt,
-      };
+      return serializeDomain(existingDomain);
     }
 
     let domainId: bigint;
@@ -107,7 +101,6 @@ export class DomainService {
       // Then, fetch WHOIS data in the background
       // This won't block the domain addition process
       this.fetchWhoisDataInBackground(domainId, sanitizedDomain);
-
     } else {
       domainId = existingDomain.id;
     }


### PR DESCRIPTION
# Context 

Against each of my domain in the list, have a refresh icon that fetches the whois info for that particular domain again.
Make sure you can refresh only once every 24 hours.
Store & Show a “last refreshed at” against each domain.

# Change summary 

**1. Created a Structured Response Type**
- Added a new DomainLookupResponse interface in domain.model.ts that includes:
- success flag to indicate operation status
- onCooldown flag for cooldown state
- hoursRemaining for time until next refresh
- message for user-friendly explanations
- domain containing the domain data

**2. Updated Domain Lookup Service**

- Modified updateDomainInfo method to return the new response type
- Fixed type compatibility issues by properly serializing domain objects
- Ensured consistent response format for both success and cooldown cases

**3. Improved API Route Handling**
- Updated the API route to handle the structured response
- Added proper type annotations to prevent TypeScript errors
- Simplified error handling by directly passing the structured response

**4. Enhanced UI Experience**
- Updated the domain-list component to handle the new API response format
- Added specific UI handling for cooldown cases with informative messages
- Improved error handling with more specific toast notifications